### PR TITLE
Add Rust open-source libraries

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,6 +84,36 @@
                 <p class="language">Rust</p>
                 <p>Rust crate to manage, convert and enrich transit data.</p>
             </a>
+            <a href="https://github.com/CanalTP/osm-transit-extractor" class="project" target="_blank">
+                <h2>OSM Transit Extractor</h2>
+                <p class="language">Rust</p>
+                <p>Extract public transport data from an OpenStreetMap</p>
+            </a>
+            <a href="https://github.com/CanalTP/typed_index_collection" class="project" target="_blank">
+                <h2>Typed Index Collection</h2>
+                <p class="language">Rust</p>
+                <p>Generic Indexed Collection.</p>
+            </a>
+            <a href="https://github.com/CanalTP/relational_types" class="project" target="_blank">
+                <h2>Relational Types</h2>
+                <p class="language">Rust</p>
+                <p>Modeling relations between objects.</p>
+            </a>
+            <a href="https://github.com/CanalTP/minidom_ext" class="project" target="_blank">
+                <h2>Minidom Ext</h2>
+                <p class="language">Rust</p>
+                <p>Extension API for Minidom.</p>
+            </a>
+            <a href="https://github.com/CanalTP/minidom_writer" class="project" target="_blank">
+                <h2>Minidom Writer</h2>
+                <p class="language">Rust</p>
+                <p>Provide writing capabilities to Minidom.</p>
+            </a>
+            <a href="https://github.com/CanalTP/skip_error" class="project" target="_blank">
+                <h2>Skip Error</h2>
+                <p class="language">Rust</p>
+                <p>Small utility to bypass errors in a loop (and optionally log it).</p>
+            </a>
         </section><!-- sub -->
         <section class="sub">
             <h3>Tools</h3>


### PR DESCRIPTION
A bunch of open-source libraries extracted from [`transit_model`](https://github.com/CanalTP/transit_model) project.